### PR TITLE
Call `eachMessage` with the correct signature, including topic

### DIFF
--- a/__mocks__/kafkajs.js
+++ b/__mocks__/kafkajs.js
@@ -66,7 +66,9 @@ kafkajs.Kafka = class Kafka {
       Object.values(this.topics[topic]).forEach((consumers) => {
         const consumerToGetMessage = Math.floor(Math.random() * consumers.length);
         consumers[consumerToGetMessage].eachMessage({
+          topic,
           message,
+          partition: message.partition,
         });
       });
     });


### PR DESCRIPTION
The [eachMessage callback](https://kafka.js.org/docs/consuming#a-name-each-message-a-eachmessage) should be passed the topic and partition. This is essential for implementing multi-topic handlers.